### PR TITLE
Remove declaration of assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ For given `math.js` below,
 ```javascript
 'use strict';
 
+var assert = require('assert');
+
 function add (a, b) {
     console.assert(typeof a === 'number');
     assert(!isNaN(a));
@@ -78,7 +80,35 @@ Run `babel` with `--plugins unassert` to transform tests.
 $ $(npm bin)/babel --plugins unassert /path/to/demo/math.js > /path/to/build/math.js
 ```
 
-You will see assert calls disappear.
+You will see assert calls and declarations disappear.
+
+```javascript
+'use strict';
+
+function add(a, b) {
+    return a + b;
+}
+```
+
+
+#### ES6 module and power-assert support
+
+babel-plugin-unassert supports ES6 module syntax and [power-assert](http://github.com/power-assert-js/power-assert).
+
+```javascript
+'use strict';
+
+import assert from 'power-assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}
+```
+
+becomes
 
 ```javascript
 'use strict';

--- a/index.js
+++ b/index.js
@@ -46,6 +46,12 @@ function matches (node) {
     };
 }
 
+function equivalentTree (node) {
+    return function (example) {
+        return deepEqual(espurify(node), example);
+    };
+}
+
 module.exports = function (babel) {
     var matchers = patterns.map(function (pattern) {
         return escallmatch(pattern, { visitorKeys: babel.types.VISITOR_KEYS });
@@ -69,7 +75,7 @@ module.exports = function (babel) {
         return Object.keys(blacklist).reduce(function (handlers, key) {
             handlers[key] = {
                 enter: function (currentNode, parentNode, scope, file) {
-                    if (blacklist[key].some(function (node) { return deepEqual(espurify(currentNode), node); })) {
+                    if (blacklist[key].some(equivalentTree(currentNode))) {
                         this.dangerouslyRemove();
                     }
                 }

--- a/index.js
+++ b/index.js
@@ -49,6 +49,34 @@ var assertImportDeclaration = {
     }
 };
 
+var assertVariableDeclaration = {
+    type: 'VariableDeclaration',
+    declarations: [
+        {
+            type: 'VariableDeclarator',
+            id: {
+                type: 'Identifier',
+                name: 'assert'
+            },
+            init: {
+                type: 'CallExpression',
+                callee: {
+                    type: 'Identifier',
+                    name: 'require'
+                },
+                arguments: [
+                    {
+                        type: 'Literal',
+                        value: 'assert'
+                    }
+                ]
+            }
+        }
+    ],
+    kind: 'var'
+};
+
+
 function matches (node) {
     return function (matcher) {
         return matcher.test(node);
@@ -64,6 +92,13 @@ module.exports = function (babel) {
         ImportDeclaration: {
             enter: function (currentNode, parentNode, scope, file) {
                 if (deepEqual(espurify(currentNode), assertImportDeclaration)) {
+                    this.dangerouslyRemove();
+                }
+            }
+        },
+        VariableDeclaration: {
+            enter: function (currentNode, parentNode, scope, file) {
+                if (deepEqual(espurify(currentNode), assertVariableDeclaration)) {
                     this.dangerouslyRemove();
                 }
             }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ var patterns = [
 
 var declarationPatterns = [
     'import assert from "assert"',
-    'var assert = require("assert")'
+    'var assert = require("assert")',
+    'import assert from "power-assert"',
+    'var assert = require("power-assert")'
 ];
 
 function matches (node) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "deep-equal": "^1.0.0",
     "escallmatch": "^1.4.2",
-    "espurify": "^1.3.0"
+    "espurify": "^1.3.0",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "babel": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "bugs": "https://github.com/twada/babel-plugin-unassert/issues",
   "dependencies": {
-    "escallmatch": "^1.4.2"
+    "deep-equal": "^1.0.0",
+    "escallmatch": "^1.4.2",
+    "espurify": "^1.3.0"
   },
   "devDependencies": {
     "babel": "^5.5.0",

--- a/test/fixtures/commonjs/expected.js
+++ b/test/fixtures/commonjs/expected.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/commonjs/fixture.js
+++ b/test/fixtures/commonjs/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var assert = require('assert');
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/commonjs_powerassert/expected.js
+++ b/test/fixtures/commonjs_powerassert/expected.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/commonjs_powerassert/fixture.js
+++ b/test/fixtures/commonjs_powerassert/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var assert = require('power-assert');
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/commonjs_singlevar/expected.js
+++ b/test/fixtures/commonjs_singlevar/expected.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var foo = 'FOO',
+    bar = 'BAR';
+
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/commonjs_singlevar/fixture.js
+++ b/test/fixtures/commonjs_singlevar/fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var foo = 'FOO',
+    assert = require('assert'),
+    bar = 'BAR';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/es6module/expected.js
+++ b/test/fixtures/es6module/expected.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/es6module/fixture.js
+++ b/test/fixtures/es6module/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import assert from 'assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/es6module_powerassert/expected.js
+++ b/test/fixtures/es6module_powerassert/expected.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/es6module_powerassert/fixture.js
+++ b/test/fixtures/es6module_powerassert/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import assert from 'power-assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -24,4 +24,6 @@ describe('babel-plugin-unassert', function () {
     testTransform('commonjs');
     testTransform('commonjs_singlevar');
     testTransform('es6module');
+    testTransform('commonjs_powerassert');
+    testTransform('es6module_powerassert');
 });

--- a/test/test.js
+++ b/test/test.js
@@ -21,4 +21,5 @@ function testTransform (fixtureName, extraOptions) {
 
 describe('babel-plugin-unassert', function () {
     testTransform('func');
+    testTransform('es6module');
 });

--- a/test/test.js
+++ b/test/test.js
@@ -22,5 +22,6 @@ function testTransform (fixtureName, extraOptions) {
 describe('babel-plugin-unassert', function () {
     testTransform('func');
     testTransform('commonjs');
+    testTransform('commonjs_singlevar');
     testTransform('es6module');
 });

--- a/test/test.js
+++ b/test/test.js
@@ -21,5 +21,6 @@ function testTransform (fixtureName, extraOptions) {
 
 describe('babel-plugin-unassert', function () {
     testTransform('func');
+    testTransform('commonjs');
     testTransform('es6module');
 });


### PR DESCRIPTION
Trying to remove declaration of `assert` as well.

```javascript
'use strict';

var assert = require('assert');

function add (a, b) {
    assert(!isNaN(a));
    assert.equal(typeof b, 'number');
    assert.ok(!isNaN(b));
    return a + b;
}
```
to
```javascript
'use strict';

function add(a, b) {
    return a + b;
}
```

And, remove ES6 import declaration too.

```javascript
'use strict';

import assert from 'assert';

function add (a, b) {
    assert(!isNaN(a));
    assert.equal(typeof b, 'number');
    assert.ok(!isNaN(b));
    return a + b;
}
```
becomes
```javascript
'use strict';

function add(a, b) {
    return a + b;
}
```

#### TODO

- [x] CommonJS
- [x] Single var pattern
- [x] ES6 modules
- [x] Remove power-assert declaration as well
- [x] Update README