### PR TITLE
Support ImportNamespaceSpecifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function (babel) {
                         return;
                     }
                     var firstSpecifier = nodePath.get('specifiers')[0];
-                    if (!firstSpecifier.isImportDefaultSpecifier()) {
+                    if (!(firstSpecifier.isImportDefaultSpecifier() || firstSpecifier.isImportNamespaceSpecifier())) {
                         return;
                     }
                     var local = firstSpecifier.get('local');

--- a/test/fixtures/es6module_namespece/expected.js
+++ b/test/fixtures/es6module_namespece/expected.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/es6module_namespece/fixture.js
+++ b/test/fixtures/es6module_namespece/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import * as assert from 'assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,7 @@ describe('babel-plugin-unassert', function () {
     testTransform('es6module_powerassert');
     testTransform('assignment');
     testTransform('assignment_singlevar');
+    testTransform('es6module_namespece');
 });
 
 describe('babel-plugin-unassert with presets', function () {
@@ -43,4 +44,5 @@ describe('babel-plugin-unassert with presets', function () {
     testTransform('es6module_powerassert', opt);
     testTransform('assignment', opt);
     testTransform('assignment_singlevar', opt, 'presets-es2015');
+    testTransform('es6module_namespece', opt);
 });


### PR DESCRIPTION
fixes #3 

before:
```js
import * as assert from 'assert';

function add (a, b) {
    assert(!isNaN(a));
    assert.equal(typeof b, 'number');
    assert.ok(!isNaN(b));
    return a + b;
}
```

after:
```js
function add(a, b) {
    return a + b;
}
```
