### PR TITLE
Replace assertion with EmptyStatement if it is not a grandchild of BlockStatement

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,15 @@ module.exports = function (babel) {
                         || callee.matchesPattern('assert', true)
                         || callee.matchesPattern('console.assert')
                        ) {
-                           nodePath.remove();
+                           if (nodePath.parentPath
+                               && nodePath.parentPath.isExpressionStatement()
+                               && nodePath.parentPath.parentPath) {
+                               if (nodePath.parentPath.parentPath.isBlockStatement()) {
+                                   nodePath.remove();
+                               } else {
+                                   nodePath.replaceWith(babel.types.emptyStatement());
+                               }
+                           }
                        }
                 }
             }

--- a/test/fixtures/conditional/expected.js
+++ b/test/fixtures/conditional/expected.js
@@ -1,0 +1,6 @@
+'use strict';
+
+function add(a, b) {
+    if (!isNaN(a)) undefined;
+    return a + b;
+}

--- a/test/fixtures/conditional/expected.js
+++ b/test/fixtures/conditional/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
 function add(a, b) {
-    if (!isNaN(a)) undefined;
+    if (!isNaN(a)) void 0;
     return a + b;
 }

--- a/test/fixtures/conditional/expected.js
+++ b/test/fixtures/conditional/expected.js
@@ -2,5 +2,6 @@
 
 function add(a, b) {
     if (!isNaN(a)) void 0;
+    if (typeof b === 'number') {}
     return a + b;
 }

--- a/test/fixtures/conditional/fixture.js
+++ b/test/fixtures/conditional/fixture.js
@@ -4,5 +4,8 @@ var assert = require('assert');
 
 function add (a, b) {
     if (!isNaN(a)) assert(0 < a);
+    if (typeof b === 'number') {
+        assert(0 < b);
+    }
     return a + b;
 }

--- a/test/fixtures/conditional/fixture.js
+++ b/test/fixtures/conditional/fixture.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var assert = require('assert');
+
+function add (a, b) {
+    if (!isNaN(a)) assert(0 < a);
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,7 @@ function testTransform (fixtureName, extraOptions, extraSuffix) {
 
 describe('babel-plugin-unassert', function () {
     testTransform('func');
+    testTransform('conditional');
     testTransform('commonjs');
     testTransform('commonjs_singlevar');
     testTransform('es6module');


### PR DESCRIPTION
Dealing with IfStatement without curly braces.

refs twada/unassert#7

```js
'use strict';

var assert = require('assert');

function add (a, b) {
    if (!isNaN(a)) assert(0 < a);
    if (typeof b === 'number') {
        assert(0 < b);
    }
    return a + b;
}
```

becomes

```js
'use strict';

function add(a, b) {
    if (!isNaN(a)) void 0;
    if (typeof b === 'number') {}
    return a + b;
}
```


#### TODO

- [x] add failing reproduction test 
- [x] fix it
